### PR TITLE
Advanced quiz settings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,9 @@ function App() {
   }, []);
 
   const fetchQuestions = async (category = "", difficulty = "") => {
-    const base = `https://opentdb.com/api.php?amount=10${
+    const amount = Number(localStorage.getItem("questionAmount")) || 10;
+
+    const base = `https://opentdb.com/api.php?amount=${amount}${
       category ? `&category=${category}` : ""
     }${difficulty ? `&difficulty=${difficulty}` : ""}&type=multiple&encode=url3986${
       token ? `&token=${token}` : ""
@@ -37,7 +39,6 @@ function App() {
 
     const { data } = await axios.get(base);
 
-    // response_code: 0=OK, 4=Token empty (pool exhausted)
     if (data.response_code === 4 && token) {
       await axios.get(
         `https://opentdb.com/api_token.php?command=reset&token=${token}`

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 import "./App.css";
 import Footer from "./components/Footer/Footer";
@@ -12,13 +12,40 @@ function App() {
   const [questions, setQuestions] = useState();
   const [name, setName] = useState();
   const [score, setScore] = useState(0);
+  const [token, setToken] = useState(null);
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const { data } = await axios.get(
+          "https://opentdb.com/api_token.php?command=request"
+        );
+        setToken(data.token);
+      } catch (e) {
+        console.error("Failed to fetch OpenTDB token", e);
+      }
+    };
+    init();
+  }, []);
 
   const fetchQuestions = async (category = "", difficulty = "") => {
-    const { data } = await axios.get(
-      `https://opentdb.com/api.php?amount=10${
-        category && `&category=${category}`
-      }${difficulty && `&difficulty=${difficulty}`}&type=multiple`
-    );
+    const base = `https://opentdb.com/api.php?amount=10${
+      category ? `&category=${category}` : ""
+    }${difficulty ? `&difficulty=${difficulty}` : ""}&type=multiple&encode=url3986${
+      token ? `&token=${token}` : ""
+    }`;
+
+    const { data } = await axios.get(base);
+
+    // response_code: 0=OK, 4=Token empty (pool exhausted)
+    if (data.response_code === 4 && token) {
+      await axios.get(
+        `https://opentdb.com/api_token.php?command=reset&token=${token}`
+      );
+      const retry = await axios.get(base);
+      setQuestions(retry.data.results);
+      return;
+    }
 
     setQuestions(data.results);
   };
@@ -29,11 +56,7 @@ function App() {
         <Header />
         <Switch>
           <Route path="/" exact>
-            <Home
-              name={name}
-              setName={setName}
-              fetchQuestions={fetchQuestions}
-            />
+            <Home name={name} setName={setName} fetchQuestions={fetchQuestions} />
           </Route>
           <Route path="/quiz">
             <Quiz

--- a/src/Pages/Home/Home.js
+++ b/src/Pages/Home/Home.js
@@ -9,15 +9,17 @@ const Home = ({ name, setName, fetchQuestions }) => {
   const [category, setCategory] = useState("");
   const [difficulty, setDifficulty] = useState("");
   const [error, setError] = useState(false);
+  const [markingScheme, setMarkingScheme] = useState(""); 
 
   const history = useHistory();
 
   const handleSubmit = () => {
-    if (!category || !difficulty || !name) {
+    if (!category || !difficulty || !name || !markingScheme) {
       setError(true);
       return;
     } else {
       setError(false);
+       localStorage.setItem("markingScheme", markingScheme);
       fetchQuestions(category, difficulty);
       history.push("/quiz");
     }
@@ -28,7 +30,7 @@ const Home = ({ name, setName, fetchQuestions }) => {
       <div className="settings">
         <span style={{ fontSize: 30 }}>Quiz Settings</span>
         <div className="settings__select">
-          {error && <ErrorMessage>Please Fill all the feilds</ErrorMessage>}
+           {error && <ErrorMessage>Please Fill all the feilds</ErrorMessage>}
           <TextField
             style={{ marginBottom: 25 }}
             label="Enter Your Name"
@@ -67,6 +69,21 @@ const Home = ({ name, setName, fetchQuestions }) => {
               Hard
             </MenuItem>
           </TextField>
+           <TextField
+            select
+            label="Select Marking Scheme"
+            value={markingScheme}
+            onChange={(e) => setMarkingScheme(e.target.value)}
+            variant="outlined"
+            style={{ marginBottom: 30 }}
+          >
+            <MenuItem key="Normal" value="normal">
+              Normal Marking
+            </MenuItem>
+           <MenuItem key="Negative" value="negative">
+             Negative Marking
+            </MenuItem>
+         </TextField>
           <Button
             variant="contained"
             color="primary"

--- a/src/Pages/Home/Home.js
+++ b/src/Pages/Home/Home.js
@@ -3,13 +3,15 @@ import { useState } from "react";
 import { useHistory } from "react-router";
 import ErrorMessage from "../../components/ErrorMessage/ErrorMessage";
 import Categories from "../../Data/Categories";
+import AdvancedPopup from "../../components/Popup/Popup";
 import "./Home.css";
 
 const Home = ({ name, setName, fetchQuestions }) => {
   const [category, setCategory] = useState("");
   const [difficulty, setDifficulty] = useState("");
   const [error, setError] = useState(false);
-  const [markingScheme, setMarkingScheme] = useState(""); 
+  const [markingScheme, setMarkingScheme] = useState("");
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const history = useHistory();
 
@@ -19,7 +21,7 @@ const Home = ({ name, setName, fetchQuestions }) => {
       return;
     } else {
       setError(false);
-       localStorage.setItem("markingScheme", markingScheme);
+      localStorage.setItem("markingScheme", markingScheme);
       fetchQuestions(category, difficulty);
       history.push("/quiz");
     }
@@ -30,7 +32,7 @@ const Home = ({ name, setName, fetchQuestions }) => {
       <div className="settings">
         <span style={{ fontSize: 30 }}>Quiz Settings</span>
         <div className="settings__select">
-           {error && <ErrorMessage>Please Fill all the feilds</ErrorMessage>}
+          {error && <ErrorMessage>Please Fill all the feilds</ErrorMessage>}
           <TextField
             style={{ marginBottom: 25 }}
             label="Enter Your Name"
@@ -69,7 +71,7 @@ const Home = ({ name, setName, fetchQuestions }) => {
               Hard
             </MenuItem>
           </TextField>
-           <TextField
+          <TextField
             select
             label="Select Marking Scheme"
             value={markingScheme}
@@ -80,20 +82,38 @@ const Home = ({ name, setName, fetchQuestions }) => {
             <MenuItem key="Normal" value="normal">
               Normal Marking
             </MenuItem>
-           <MenuItem key="Negative" value="negative">
-             Negative Marking
+            <MenuItem key="Negative" value="negative">
+              Negative Marking
             </MenuItem>
-         </TextField>
-          <Button
-            variant="contained"
-            color="primary"
-            size="large"
-            onClick={handleSubmit}
-          >
-            Start Quiz
-          </Button>
+          </TextField>
+
+          <div style={{ display: "flex", gap: 12, marginBottom: 20 }}>
+            <Button
+              variant="outlined"
+              color="default"
+              size="large"
+              onClick={() => setShowAdvanced(true)}
+            >
+              Advanced Quiz Settings
+            </Button>
+            <Button
+              variant="contained"
+              color="primary"
+              size="large"
+              onClick={handleSubmit}
+            >
+              Start Quiz
+            </Button>
+          </div>
         </div>
       </div>
+
+      <AdvancedPopup
+        open={showAdvanced}
+        onClose={() => setShowAdvanced(false)}
+        onApply={() => setShowAdvanced(false)}
+      />
+
       <img src="/quiz.svg" className="banner" alt="quiz app" />
     </div>
   );

--- a/src/Pages/Quiz/Quiz.js
+++ b/src/Pages/Quiz/Quiz.js
@@ -3,28 +3,24 @@ import { useEffect, useState } from "react";
 import Question from "../../components/Question/Question";
 import "./Quiz.css";
 
+const decode = (s) => {
+  try { return decodeURIComponent(s); } catch { return s; }
+};
+
 const Quiz = ({ name, questions, score, setScore, setQuestions }) => {
   const [options, setOptions] = useState();
   const [currQues, setCurrQues] = useState(0);
   const [correctCount, setCorrectCount] = useState(0);
   const [wrongCount, setWrongCount] = useState(0);
 
-
   useEffect(() => {
-    setOptions(
-      questions &&
-        handleShuffle([
-          questions[currQues]?.correct_answer,
-          ...questions[currQues]?.incorrect_answers,
-        ])
-    );
+    if (!questions) return;
+    const correct = decode(questions[currQues]?.correct_answer || "");
+    const incorrect = (questions[currQues]?.incorrect_answers || []).map(decode);
+    setOptions(handleShuffle([correct, ...incorrect]));
   }, [currQues, questions]);
 
-  console.log(questions);
-
-  const handleShuffle = (options) => {
-    return options.sort(() => Math.random() - 0.5);
-  };
+  const handleShuffle = (arr) => arr.sort(() => Math.random() - 0.5);
 
   return (
     <div className="quiz">
@@ -33,18 +29,15 @@ const Quiz = ({ name, questions, score, setScore, setQuestions }) => {
       {questions ? (
         <>
           <div className="quizInfo">
-            <span>{questions[currQues].category}</span>
-            <span>
-              {/* {questions[currQues].difficulty} */}
-              Score : {score}
-            </span>
+            <span>{decode(questions[currQues].category)}</span>
+            <span>Score : {score}</span>
           </div>
           <Question
             currQues={currQues}
             setCurrQues={setCurrQues}
             questions={questions}
             options={options}
-            correct={questions[currQues]?.correct_answer}
+            correct={decode(questions[currQues]?.correct_answer || "")}
             score={score}
             setScore={setScore}
             setQuestions={setQuestions}

--- a/src/Pages/Quiz/Quiz.js
+++ b/src/Pages/Quiz/Quiz.js
@@ -6,6 +6,9 @@ import "./Quiz.css";
 const Quiz = ({ name, questions, score, setScore, setQuestions }) => {
   const [options, setOptions] = useState();
   const [currQues, setCurrQues] = useState(0);
+  const [correctCount, setCorrectCount] = useState(0);
+  const [wrongCount, setWrongCount] = useState(0);
+
 
   useEffect(() => {
     setOptions(
@@ -45,6 +48,10 @@ const Quiz = ({ name, questions, score, setScore, setQuestions }) => {
             score={score}
             setScore={setScore}
             setQuestions={setQuestions}
+            correctCount={correctCount}
+            wrongCount={wrongCount}
+            setCorrectCount={setCorrectCount}
+            setWrongCount={setWrongCount}
           />
         </>
       ) : (

--- a/src/Pages/Result/Result.js
+++ b/src/Pages/Result/Result.js
@@ -1,10 +1,12 @@
 import { Button } from "@material-ui/core";
 import { useEffect } from "react";
-import { useHistory } from "react-router";
+import { useHistory, useLocation } from "react-router";
 import "./Result.css";
 
-const Result = ({ name, score }) => {
+const Result = ({ name }) => {
   const history = useHistory();
+  const location = useLocation();
+  const { score = 0, correctCount = 0, wrongCount = 0 } = location.state || {};
 
   useEffect(() => {
     if (!name) {
@@ -15,6 +17,10 @@ const Result = ({ name, score }) => {
   return (
     <div className="result">
       <span className="title">Final Score : {score}</span>
+      <div className="details">
+        <p>Correct Answers: {correctCount}</p>
+        <p>Wrong Answers: {wrongCount}</p>
+      </div>
       <Button
         variant="contained"
         color="secondary"

--- a/src/components/Popup/Popup.js
+++ b/src/components/Popup/Popup.js
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  MenuItem,
+  TextField,
+} from "@material-ui/core";
+
+const timerOptions = [
+  { label: "No Timer", value: 0 },
+  { label: "15 seconds/question", value: 15 },
+  { label: "30 seconds/question", value: 30 },
+  { label: "45 seconds/question", value: 45 },
+  { label: "60 seconds/question", value: 60 },
+  { label: "90 seconds/question", value: 90 },
+];
+
+const skipOptions = [
+  { label: "Allow Skipping", value: "true" },
+  { label: "Do Not Allow Skipping", value: "false" },
+];
+
+export default function AdvancedPopup({ open, onClose, onApply }) {
+  const [timerSeconds, setTimerSeconds] = useState(
+    Number(localStorage.getItem("quizTimerSeconds") || 0)
+  );
+  const [allowSkip, setAllowSkip] = useState(
+    String(localStorage.getItem("allowSkip") || "true")
+  );
+  const [questionAmount, setQuestionAmount] = useState(
+    Number(localStorage.getItem("questionAmount") || 10)
+  );
+
+  const handleApply = () => {
+    localStorage.setItem("quizTimerSeconds", String(timerSeconds));
+    localStorage.setItem("allowSkip", String(allowSkip));
+    localStorage.setItem("questionAmount", String(questionAmount));
+    onApply?.({ timerSeconds, allowSkip: allowSkip === "true", questionAmount });
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Advanced Quiz Settings</DialogTitle>
+      <DialogContent dividers>
+        <TextField
+          select
+          label="Timer"
+          value={timerSeconds}
+          onChange={(e) => setTimerSeconds(Number(e.target.value))}
+          variant="outlined"
+          fullWidth
+          style={{ marginBottom: 20 }}
+        >
+          {timerOptions.map((opt) => (
+            <MenuItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </MenuItem>
+          ))}
+        </TextField>
+
+        <TextField
+          select
+          label="Skipping"
+          value={allowSkip}
+          onChange={(e) => setAllowSkip(String(e.target.value))}
+          variant="outlined"
+          fullWidth
+          style={{ marginBottom: 20 }}
+        >
+          {skipOptions.map((opt) => (
+            <MenuItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </MenuItem>
+          ))}
+        </TextField>
+
+        <TextField
+          type="number"
+          label="Number of Questions"
+          value={questionAmount}
+          onChange={(e) =>
+            setQuestionAmount(Math.max(1, Number(e.target.value || 1)))
+          }
+          variant="outlined"
+          fullWidth
+          inputProps={{ min: 1, max: 100 }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="default" variant="outlined">
+          Cancel
+        </Button>
+        <Button
+          onClick={() => {
+            handleApply();
+            onClose?.();
+          }}
+          color="primary"
+          variant="contained"
+        >
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useHistory } from "react-router";
 import "./Question.css";
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
+import { getNextScore } from "../Score/Score";
 
 const Question = ({
   currQues,
@@ -13,6 +14,10 @@ const Question = ({
   setScore,
   score,
   setQuestions,
+  setCorrectCount,
+  setWrongCount,
+  correctCount,
+  wrongCount,
 }) => {
   const [selected, setSelected] = useState();
   const [error, setError] = useState(false);
@@ -27,17 +32,27 @@ const Question = ({
 
   const handleCheck = (i) => {
     setSelected(i);
-    if (i === correct) setScore(score + 1);
+    const isCorrect = i === correct;
+    setScore(getNextScore(score, isCorrect));
+    if (isCorrect) setCorrectCount(correctCount + 1);
+    else setWrongCount(wrongCount + 1);
     setError(false);
   };
 
   const handleNext = () => {
-    if (currQues > 8) {
-      history.push("/result");
+    const isLast = currQues >= (questions?.length ?? 0) - 1;
+    if (isLast) {
+      if (selected) {
+        history.push("/result", { score, correctCount, wrongCount });
+      } else {
+        setError("Please select an option first");
+      }
     } else if (selected) {
       setCurrQues(currQues + 1);
       setSelected();
-    } else setError("Please select an option first");
+    } else {
+      setError("Please select an option first");
+    }
   };
 
   const handleQuit = () => {
@@ -83,7 +98,7 @@ const Question = ({
             style={{ width: 185 }}
             onClick={handleNext}
           >
-            {currQues > 20 ? "Submit" : "Next Question"}
+            {currQues >= (questions?.length ?? 0) - 1 ? "Submit" : "Next Question"}
           </Button>
         </div>
       </div>

--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -1,9 +1,13 @@
 import { Button } from "@material-ui/core";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useHistory } from "react-router";
 import "./Question.css";
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import { getNextScore } from "../Score/Score";
+
+const decode = (s) => {
+  try { return decodeURIComponent(s); } catch { return s; }
+};
 
 const Question = ({
   currQues,
@@ -24,6 +28,35 @@ const Question = ({
 
   const history = useHistory();
 
+  const allowSkip = (localStorage.getItem("allowSkip") ?? "true") !== "false";
+  const perQuestionTimer = Number(localStorage.getItem("quizTimerSeconds") || 0);
+  const [timeLeft, setTimeLeft] = useState(perQuestionTimer);
+  const timerRef = useRef(null);
+
+  useEffect(() => {
+    if (perQuestionTimer > 0) {
+      setTimeLeft(perQuestionTimer);
+      if (timerRef.current) clearInterval(timerRef.current);
+      timerRef.current = setInterval(() => {
+        setTimeLeft((t) => {
+          if (t <= 1) {
+            clearInterval(timerRef.current);
+            timerRef.current = null;
+            handleTimeout();
+            return 0;
+          }
+          return t - 1;
+        });
+      }, 1000);
+    }
+    return () => {
+      if (timerRef.current) { clearInterval(timerRef.current); timerRef.current = null; }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currQues, perQuestionTimer]);
+
+  const stopTimer = () => { if (timerRef.current) { clearInterval(timerRef.current); timerRef.current = null; } };
+
   const handleSelect = (i) => {
     if (selected === i && selected === correct) return "select";
     else if (selected === i && selected !== correct) return "wrong";
@@ -32,40 +65,64 @@ const Question = ({
 
   const handleCheck = (i) => {
     setSelected(i);
+    stopTimer();
     const isCorrect = i === correct;
-    setScore(getNextScore(score, isCorrect));
-    if (isCorrect) setCorrectCount(correctCount + 1);
-    else setWrongCount(wrongCount + 1);
+    setScore((prev) => getNextScore(prev, isCorrect));
+    if (isCorrect) setCorrectCount((c) => c + 1);
+    else setWrongCount((w) => w + 1);
     setError(false);
   };
 
-  const handleNext = () => {
+  const goNext = () => {
     const isLast = currQues >= (questions?.length ?? 0) - 1;
     if (isLast) {
-      if (selected) {
-        history.push("/result", { score, correctCount, wrongCount });
-      } else {
-        setError("Please select an option first");
-      }
-    } else if (selected) {
-      setCurrQues(currQues + 1);
-      setSelected();
+      history.push("/result", { score, correctCount, wrongCount });
     } else {
+      setCurrQues(currQues + 1);
+      setSelected(undefined);
+      setError(false);
+    }
+  };
+
+  const handleNext = () => {
+    if (!selected && !allowSkip) {
       setError("Please select an option first");
+      return;
+    }
+    goNext();
+  };
+
+  const handleTimeout = () => {
+    if (selected == null) {
+      setScore((prev) => getNextScore(prev, false));
+      setWrongCount((w) => w + 1);
+      goNext();
     }
   };
 
   const handleQuit = () => {
+    stopTimer();
     setCurrQues(0);
     setQuestions();
   };
 
+  const totalQ = questions?.length ?? 0;
+
   return (
     <div className="question">
-      <h1>Question {currQues + 1} :</h1>
+      <div className="question__header">
+        <h1>
+          Question {currQues + 1} / {totalQ}
+        </h1>
+        {perQuestionTimer > 0 && (
+          <div className="timer" aria-live="polite">
+            Time left: {timeLeft}s
+          </div>
+        )}
+      </div>
 
       <div className="singleQuestion">
-        <h2>{questions[currQues].question}</h2>
+        <h2>{decode(questions[currQues].question)}</h2>
         <div className="options">
           {error && <ErrorMessage>{error}</ErrorMessage>}
           {options &&
@@ -74,7 +131,7 @@ const Question = ({
                 className={`singleOption  ${selected && handleSelect(i)}`}
                 key={i}
                 onClick={() => handleCheck(i)}
-                disabled={selected}
+                disabled={!!selected}
               >
                 {i}
               </button>
@@ -87,7 +144,7 @@ const Question = ({
             size="large"
             style={{ width: 185 }}
             href="/"
-            onClick={() => handleQuit()}
+            onClick={handleQuit}
           >
             Quit
           </Button>
@@ -98,7 +155,7 @@ const Question = ({
             style={{ width: 185 }}
             onClick={handleNext}
           >
-            {currQues >= (questions?.length ?? 0) - 1 ? "Submit" : "Next Question"}
+            {currQues >= totalQ - 1 ? "Submit" : allowSkip ? "Skip / Next" : "Next"}
           </Button>
         </div>
       </div>

--- a/src/components/Score/Score.css
+++ b/src/components/Score/Score.css
@@ -1,0 +1,39 @@
+/* score.css */
+/* Optional styles if you want to display the active marking scheme in your UI. */
+
+.score-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 14px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  user-select: none;
+  border: 1px solid rgba(0,0,0,0.08);
+}
+
+.score-badge__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.score-badge--normal {
+  background: #f3faf5;
+  color: #0b6b3a;
+}
+
+.score-badge--normal .score-badge__dot {
+  background: #19a463;
+}
+
+.score-badge--negative {
+  background: #fff5f5;
+  color: #a12a2a;
+}
+
+.score-badge--negative .score-badge__dot {
+  background: #e25555;
+}

--- a/src/components/Score/Score.js
+++ b/src/components/Score/Score.js
@@ -1,0 +1,49 @@
+export const SCHEMES = {
+  NORMAL: "normal",
+  NEGATIVE: "negative",
+};
+
+const LS_KEYS = {
+  SCHEME: "markingScheme",
+  PENALTY: "negativePenalty",
+};
+
+export function readMarkingScheme() {
+  const raw = (localStorage.getItem(LS_KEYS.SCHEME) || SCHEMES.NORMAL).toLowerCase();
+  return raw === SCHEMES.NEGATIVE ? SCHEMES.NEGATIVE : SCHEMES.NORMAL;
+}
+
+export function readPenalty() {
+  const stored = localStorage.getItem(LS_KEYS.PENALTY);
+  const num = stored ? Number(stored) : NaN;
+  return Number.isFinite(num) && num >= 0 ? num : 0.25;
+}
+
+export function applyNormalMarking(currentScore, isCorrect) {
+  return isCorrect ? currentScore + 1 : currentScore;
+}
+
+export function applyNegativeMarking(currentScore, isCorrect, penalty = readPenalty()) {
+  if (isCorrect) return currentScore + 1;
+  return currentScore - penalty;
+}
+
+export function getNextScore(currentScore, isCorrect) {
+  const scheme = readMarkingScheme();
+  if (scheme === SCHEMES.NEGATIVE) {
+    return applyNegativeMarking(currentScore, isCorrect);
+  }
+  return applyNormalMarking(currentScore, isCorrect);
+}
+
+export function getSchemeLabel(scheme = readMarkingScheme()) {
+  return scheme === SCHEMES.NEGATIVE ? "Negative Marking" : "Normal Marking";
+}
+
+export function getSchemeMeta() {
+  const scheme = readMarkingScheme();
+  return {
+    scheme,
+    penalty: scheme === SCHEMES.NEGATIVE ? readPenalty() : 0,
+  };
+}


### PR DESCRIPTION
**PR: Advanced quiz settings, scoring revamp, and text decode fixes**

* Added **Marking Scheme** (Normal / Negative) in Home; new `components/Score/score.js` drives scoring (wrong answers can go below 0).
* New **Advanced Quiz Settings** modal `components/Popup/Popup.js`: per-question **timer**, **allow/disallow skipping**, and **question count**; values stored in `localStorage`.
* **Timer** shown in Question; **auto-counts wrong** and advances on timeout.
* **Skip control** enforced: blocks Next when skipping is disallowed; button label reflects “Skip / Next”.
* **Question count** honored: `App.js` fetches `amount` from Advanced settings; Question header shows `Question X / Y`.
* **OpenTDB session token** added to reduce repeats; auto-reset on exhaustion.
* **Results page** now shows **Correct** and **Wrong** counts (passed via router state).


